### PR TITLE
fix: unify `orb` host config with `stylix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
         modules = [
           ./hosts/orb
           home-manager.nixosModules.home-manager
+          stylix.nixosModules.stylix
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
@@ -111,6 +112,7 @@
             home-manager.extraSpecialArgs = { inherit user inputs; };
           }
           ./modules/nixos
+          ./modules/shared
         ];
         specialArgs = specialArgs;
       };

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,4 +1,4 @@
-inputs: {
+{ ... }: {
   # Compatibility with NixOS
   home.stateVersion = "24.05";
   # Let Home Manager install and manage itself.

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -1,4 +1,4 @@
-inputs: {
+{ ... }: {
   imports = [
     ./stylix
   ];

--- a/modules/shared/stylix/default.nix
+++ b/modules/shared/stylix/default.nix
@@ -1,15 +1,17 @@
-{ pkgs, ... }:
+{ pkgs
+, ...
+}:
 let
-  main = pkgs.cascadia-code;
+  monospace = pkgs.cascadia-code;
 in
 {
-  fonts.packages = [ main ];
+  fonts.packages = [ monospace ];
   stylix = {
     enable = true;
     base16Scheme = "${pkgs.base16-schemes}/share/themes/dracula.yaml";
     fonts = {
       monospace = {
-        package = main;
+        package = monospace;
         name = "Cascadia Code NF";
       };
     };


### PR DESCRIPTION
Currently headless `orb` host configuration cannot be activated because of missing `stylix` attributes. This PR fixes issue by adding `stylix` even tough it is redundant. This simplifies development at cost of activation and configuration eval speed.

## Changes

- Remove unused bindings to module args
- Add `stylix.nixosModules.stylix` and `./modules/shared`
- Rename `main` binding for `pkgs.cascadia-code` to `monospace`
