### PR TITLE
feat(nix): cache NetBird packages via Cachix

### DIFF
--- a/.github/workflows/netbird-packages.yml
+++ b/.github/workflows/netbird-packages.yml
@@ -1,0 +1,86 @@
+name: NetBird Packages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: netbird-packages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  packages:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            system: x86_64-linux
+            packages: netbird netbird-server netbird-proxy
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+            packages: netbird
+          - runner: macos-latest
+            system: aarch64-darwin
+            packages: netbird netbird-app
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Compute NetBird cache key
+        id: netbird-cache-key
+        run: |
+          set -euo pipefail
+          hash="$(nix build --no-link --print-out-paths --accept-flake-config \
+            ".#checks.${{ matrix.system }}.netbird-cache-key" | xargs cat)"
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: netbird-${{ matrix.system }}-${{ steps.netbird-cache-key.outputs.hash }}
+          restore-prefixes-first-match: netbird-${{ matrix.system }}-
+          gc-max-store-size-linux: 2G
+          purge: true
+          purge-prefixes: netbird-${{ matrix.system }}-
+          purge-last-accessed: P7D
+          purge-primary-key: never
+
+      - uses: cachix/cachix-action@v16
+        with:
+          name: atahanyorganci
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+
+      - name: Build NetBird packages (${{ matrix.system }})
+        run: |
+          set -euo pipefail
+          args=()
+          for pkg in ${{ matrix.packages }}; do
+            args+=(".#packages.${{ matrix.system }}.$pkg")
+          done
+          nix build -L --accept-flake-config "${args[@]}"
+
+      - name: Push NetBird packages to Cachix
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          set -euo pipefail
+          args=()
+          for pkg in ${{ matrix.packages }}; do
+            args+=(".#packages.${{ matrix.system }}.$pkg")
+          done
+          nix build --no-link --print-out-paths --accept-flake-config "${args[@]}" \
+            | cachix push atahanyorganci

--- a/modules/flake/cachix.nix
+++ b/modules/flake/cachix.nix
@@ -1,0 +1,69 @@
+{lib, ...}: let
+  cacheName = "atahanyorganci";
+  cachePublicKey = "atahanyorganci.cachix.org-1:r9ZNvFHFKPxydR+do9PhRGHk2x/MuxG5U8ilm7t9mWs=";
+  cacheUrl = "https://${cacheName}.cachix.org";
+
+  netbirdPackagesBySystem = {
+    x86_64-linux = ["netbird" "netbird-server" "netbird-proxy"];
+    aarch64-linux = ["netbird"];
+    aarch64-darwin = ["netbird" "netbird-app"];
+  };
+in {
+  options.flake.cachix = lib.mkOption {
+    type = lib.types.submodule {
+      options = {
+        cacheName = lib.mkOption {type = lib.types.str;};
+        cacheUrl = lib.mkOption {type = lib.types.str;};
+        cachePublicKey = lib.mkOption {type = lib.types.str;};
+      };
+    };
+  };
+
+  options.flake.netbirdCache = lib.mkOption {
+    type = lib.types.submodule {
+      options.packagesBySystem = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      };
+    };
+  };
+
+  config = {
+    flake.cachix = {
+      inherit cacheName cacheUrl cachePublicKey;
+    };
+
+    flake.netbirdCache = {
+      packagesBySystem = netbirdPackagesBySystem;
+    };
+
+    flake.nixConfig = {
+      extra-substituters = [cacheUrl];
+      extra-trusted-public-keys = [cachePublicKey];
+    };
+
+    flake.modules.nixos.cachix = {
+      nix.settings = {
+        extra-substituters = [cacheUrl];
+        extra-trusted-public-keys = [cachePublicKey];
+      };
+    };
+
+    perSystem = {
+      pkgs,
+      lib,
+      system,
+      ...
+    }: let
+      names = netbirdPackagesBySystem.${system} or [];
+      getDrvPath = name:
+        if builtins.hasAttr name pkgs
+        then pkgs.${name}.drvPath
+        else throw "NetBird cache check: missing package ${name} on ${system}";
+      cacheKey = builtins.hashString "sha256" (
+        lib.concatStringsSep "\n" (map getDrvPath names)
+      );
+    in {
+      checks.netbird-cache-key = pkgs.writeText "netbird-cache-key" cacheKey;
+    };
+  };
+}

--- a/modules/pkgs/netbird-server.nix
+++ b/modules/pkgs/netbird-server.nix
@@ -13,6 +13,11 @@
 
       vendorHash = "sha256-z/2+LUBocWQ06EfdJ4nujr4vb1e2zjmlufsGgGWN0ak=";
 
+      # Share the go-modules derivation name across NetBird components.
+      overrideModAttrs = _final: _prev: {
+        name = "netbird-${version}-go-modules";
+      };
+
       subPackages = ["combined"];
 
       ldflags = [


### PR DESCRIPTION
## Summary
- Add a consolidated flake Cachix module with substituters for `atahanyorganci.cachix.org`, NixOS settings, and hash-based NetBird CI cache keys.
- Add a **NetBird Packages** GitHub Actions workflow that builds custom NetBird packages on Linux and Darwin, restores the Nix store by derivation hash, and pushes to Cachix on `main`.
- Share the `netbird-*-go-modules` derivation across `netbird-server` to match client/proxy and improve cache reuse.

## Test plan
- [ ] Confirm `CACHIX_AUTH_TOKEN` is set on the repo
- [ ] Merge and verify **NetBird Packages** workflow succeeds on `main`
- [ ] Confirm mars/mercury substitute NetBird builds from `atahanyorganci.cachix.org`
- [ ] On Darwin hosts, run `cachix use atahanyorganci` once